### PR TITLE
Fix (weather): forecast auto loader use register non desired language files

### DIFF
--- a/snap/weather_forecast_loader/index.js
+++ b/snap/weather_forecast_loader/index.js
@@ -133,7 +133,9 @@ const fetchOnMessageHandler = (msg, seqno) => {
 
 		attachments.map(attachment => {
 			if (!attachment.params?.name?.toLowerCase().includes('anglais')
-			&& !attachment.params?.name?.toLowerCase().includes('italien')) {
+			&& !attachment.params?.name?.toLowerCase().includes('italien')
+			&& !attachment.params?.name?.toLowerCase().includes('espagnol')
+			&& !attachment.params?.name?.toLowerCase().includes('allemand')) {
 				console.log(prefix + 'Fetching attachment %s', attachment.params.name);
 				const f = connexion.fetch(attribute.uid, {
 					bodies: [attachment.partID],


### PR DESCRIPTION
### Description:
Currently the last forecast registered is shown in the app.
receiving the german one in last position, it was then shown.

### What has changed:
Add german and spanish to the languages exclusion rule

## What should the Reviewer know: 

